### PR TITLE
feat(docs): Corrige hiperlink e atualiza conteúdo em páginas

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -50,7 +50,7 @@ export default defineConfig({
             },
             {
                 text: "Planos",
-                link: "/changelog-and-roadmap",
+                link: "/plans",
             },
             {
                 text: "Informações técnicas",
@@ -62,7 +62,7 @@ export default defineConfig({
                     {
                         text: "Limites aplicáveis na plataforma",
                         link: "/technical-informations/limits",
-                    },
+                    },p
                     {
                         text: "Manutenções programadas e disponibilidade",
                         link: "/technical-informations/availability",

--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -62,7 +62,7 @@ export default defineConfig({
                     {
                         text: "Limites aplicáveis na plataforma",
                         link: "/technical-informations/limits",
-                    },p
+                    },
                     {
                         text: "Manutenções programadas e disponibilidade",
                         link: "/technical-informations/availability",

--- a/plans.md
+++ b/plans.md
@@ -6,7 +6,7 @@
 
 Ideal para quem está começando, o Plano Scout Starter oferece as funcionalidades essenciais para gerenciar e automatizar suas campanhas de email de forma simples e eficiente. Com limite diário de 50 envios e recursos avançados de segurança, é perfeito para procurar por uma vaga usando um orçamento menor, sem precisar se preocupar com valores muito altos.
 
-**Valor mensal: R$39,90**
+**Valor mensal: R$59,90**
 
 **Recursos Inclusos**
 
@@ -23,7 +23,7 @@ Ideal para quem está começando, o Plano Scout Starter oferece as funcionalidad
 
 Ideal para quem busca um pouco mais de alcance dentro da DevScout, o plano Scout Explorer te permite gerenciar e automatizar candidaturas de email com um limite diário de 150 envios e oferece. Com todos os recursos essenciais e suporte premium, é perfeito para quem deseja ampliar o alcance das suas campanhas mantendo o controle dos custos.
 
-**Valor mensal: R$79,90**
+**Valor mensal: R$99,90**
 
 **Recursos Inclusos**
 

--- a/plans.md
+++ b/plans.md
@@ -1,6 +1,6 @@
 # Nossos Planos
 
-> Última atualização: 23/07/2025
+> Última atualização: 28/07/2025
 
 ## 🏃 Plano Scout Starter
 


### PR DESCRIPTION
### Correção dos Valores dos Planos

Conforme atualização no dia 25/07/2025 - valores dos planos starter e explorer mudaram para 59,90 e 99,99 respectivamente.

### Correção do Hiperlink para Planos no menu lateral

Hiperlink de planos estava direcionando para Changelog e Roadmap - atualização sucinta para a página já existente de planos :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated navigation links for the "Planos" section to direct users to the new plans page.

* **Documentation**
  * Updated subscription plan prices: "Plano Scout Starter" increased to R$59,90 and "Plano Scout Explorer" increased to R$99,90. No other plan details were changed.
  * Updated the last update date on the plans page to 28/07/2025.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->